### PR TITLE
add ocm_cluster_rosa_classic data source to get cluster id/name, stat…

### DIFF
--- a/docs/data-sources/ocm_cluster_rosa_classic.md
+++ b/docs/data-sources/ocm_cluster_rosa_classic.md
@@ -1,0 +1,27 @@
+---
+page_title: "ocm_cluster_rosa_classic Data Source"
+subcategory: ""
+description: |-
+  Get ROSA cluster details.
+---
+
+# ocm_cluster_rosa_classic (Data Source)
+
+Get ROSA cluster details.
+
+## Schema
+
+### Optional
+
+- **name** (String) Name of the cluster.
+
+- **id** (String) Unique identifier of the cluster.
+
+Either name or id must be provided.
+
+  
+### Read-Only
+
+- **version** (String) Version of OpenShift used to create the cluster
+
+- **state** (String) State of the cluster.

--- a/examples/get_cluster_info/README.md
+++ b/examples/get_cluster_info/README.md
@@ -1,0 +1,6 @@
+# Cluster Data source example
+
+This example shows how to use the cluster rosa classic data source to get 
+name of the cluster from ID or ID of the cluster frm the name.
+To run it adjust the configuration of the provider in the `main.tf` file 
+and then run the `terraform apply` command.

--- a/examples/get_cluster_info/main.tf
+++ b/examples/get_cluster_info/main.tf
@@ -1,0 +1,36 @@
+terraform {
+  required_providers {
+    ocm = {
+      version = ">= 0.1"
+      source  = "openshift-online/ocm"
+    }
+  }
+}
+
+provider "ocm" {
+}
+
+data "ocm_cluster_rosa_classic" "mycluster-name" {
+    name = "my-cluster"
+}
+
+output "cluster_id"{
+    value = data.ocm_cluster_rosa_classic.mycluster-name.id //outputs: cluster_id = "1n2j3k4l5m6n7o8p9q0r"
+}
+
+data "ocm_cluster_rosa_classic" "mycluster-id" {
+    id = "1n2j3k4l5m6n7o8p9q0r"
+}
+
+output "cluster_name"{
+    value = data.ocm_cluster_rosa_classic.mycluster-id.name //outputs: cluster_name = "my-cluster"
+}
+
+output "cluster_status"{
+    value = data.ocm_cluster_rosa_classic.mycluster-id.state //outputs: cluster_status = "<cluster state>"
+}
+
+output "cluster_version"{
+    value = data.ocm_cluster_rosa_classic.mycluster-id.version // outputs: cluster_version = "<x.x.x>"
+
+}

--- a/provider/cluster_rosa_classic_data_source.go
+++ b/provider/cluster_rosa_classic_data_source.go
@@ -1,0 +1,123 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift-online/ocm-sdk-go/logging"
+)
+
+type ClusterRosaClassicDataSourceType struct {
+	logger logging.Logger
+}
+
+type ClusterRosaClassicDataSource struct {
+	logger     logging.Logger
+	collection *cmv1.ClustersClient
+}
+
+func (t *ClusterRosaClassicDataSourceType) GetSchema(ctx context.Context) (result tfsdk.Schema,
+	diags diag.Diagnostics) {
+	result = tfsdk.Schema{
+		Description: "OpenShift managed cluster using rosa sts.",
+		Attributes: map[string]tfsdk.Attribute{
+			"name": {
+				Description: "Name of the cluster.",
+				Type:        types.StringType,
+				Computed:    true,
+			},
+			//future : search with id or name instead of just name
+			"id": {
+				Description: "Unique identifier of the cluster.",
+				Type:        types.StringType,
+				Computed:    true,
+			},
+			"version": {
+				Description: "Identifier of the version of OpenShift, for example 'openshift-v4.1.0'.",
+				Type:        types.StringType,
+				Computed:    true,
+			},
+			"state": {
+				Description: "State of the cluster.",
+				Type:        types.StringType,
+				Computed:    true,
+			},
+			// to include -> STS Role ARN, Support Role ARN, Instance IAM Roles - Control plane, Instance IAM Roles - Worker, Operator IAM Roles (list), Created,Details Page,OIDC Endpoint URL
+		},
+	}
+	return
+}
+
+func (t *ClusterRosaClassicDataSourceType) NewDataSource(ctx context.Context,
+	p tfsdk.Provider) (result tfsdk.DataSource, diags diag.Diagnostics) {
+	// Cast the provider interface to the specific implementation:
+	parent := p.(*Provider)
+
+	// Get the collection of clusters:
+	collection := parent.connection.ClustersMgmt().V1().Clusters()
+
+	// Create the resource:
+	result = &ClusterRosaClassicDataSource{
+		logger:     parent.logger,
+		collection: collection,
+	}
+	return
+}
+
+func (s *ClusterRosaClassicDataSource) Read(ctx context.Context, request tfsdk.ReadDataSourceRequest,
+	response *tfsdk.ReadDataSourceResponse) {
+	// Get the state:
+	state := &DataClusterRosaClassicState{}
+	diags := request.Config.Get(ctx, state)
+	response.Diagnostics.Append(diags...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+	// Fetch the complete details of the cluster:
+	//var listItem *cmv1.Cluster
+	listRequest := s.collection.List()
+	if !state.Name.Unknown && !state.Name.Null {
+		listRequest.Search("name is '" + state.Name.Value + "'")
+	} else if !state.ID.Unknown && !state.ID.Null {
+		listRequest.Search("id is '" + state.ID.Value + "'")
+	} else {
+		response.Diagnostics.AddError(
+			"Data source requires either cluster Name or ID",
+			"",
+		)
+		return
+	}
+	listResponse, err := listRequest.SendContext(ctx)
+	if err != nil {
+		response.Diagnostics.AddError(
+			"Can't list Clusters",
+			err.Error(),
+		)
+		return
+	}
+	if listResponse.Size() > 0 {
+		// Populate the state:
+		listResponse.Items().Each(func(cluster *cmv1.Cluster) bool {
+			state.ID = types.String{
+				Value: cluster.ID(),
+			}
+			state.Name = types.String{
+				Value: cluster.Name(),
+			}
+			state.State = types.String{
+				Value: fmt.Sprintf("%s", cluster.State()),
+			}
+			state.Version = types.String{
+				Value: cluster.OpenshiftVersion(),
+			}
+			return true
+		})
+	}
+	// Save the state:
+	diags = response.State.Set(ctx, state)
+	response.Diagnostics.Append(diags...)
+}

--- a/provider/cluster_rosa_classic_state.go
+++ b/provider/cluster_rosa_classic_state.go
@@ -63,3 +63,10 @@ type InstanceIAMRole struct {
 	MasterRoleARN types.String `tfsdk:"master_role_arn"`
 	WorkerRoleARN types.String `tfsdk:"worker_role_arn"`
 }
+
+type DataClusterRosaClassicState struct {
+	ID      types.String `tfsdk:"id"`
+	Name    types.String `tfsdk:"name"`
+	State   types.String `tfsdk:"state"`
+	Version types.String `tfsdk:"version"`
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -222,11 +222,12 @@ func (p *Provider) GetResources(ctx context.Context) (result map[string]tfsdk.Re
 func (p *Provider) GetDataSources(ctx context.Context) (result map[string]tfsdk.DataSourceType,
 	diags diag.Diagnostics) {
 	result = map[string]tfsdk.DataSourceType{
-		"ocm_cloud_providers":     &CloudProvidersDataSourceType{},
-		"ocm_rosa_operator_roles": &RosaOperatorRolesDataSourceType{},
-		"ocm_groups":              &GroupsDataSourceType{},
-		"ocm_machine_types":       &MachineTypesDataSourceType{},
-		"ocm_versions":            &VersionsDataSourceType{},
+		"ocm_cloud_providers":      &CloudProvidersDataSourceType{},
+		"ocm_rosa_operator_roles":  &RosaOperatorRolesDataSourceType{},
+		"ocm_groups":               &GroupsDataSourceType{},
+		"ocm_machine_types":        &MachineTypesDataSourceType{},
+		"ocm_versions":             &VersionsDataSourceType{},
+		"ocm_cluster_rosa_classic": &ClusterRosaClassicDataSourceType{},
 	}
 	return
 }


### PR DESCRIPTION
add ocm_cluster_rosa_classic data source to get cluster id/name, state and version of existing cluster

---
title: "pr: "
labels: "Pull request"
---

# Description
Current OCM Provider does not have data source to read information about existing Openshift Cluster. this data source would search cluster by name or id and fetch information about cluster name/id, state version installed.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test 1: Fetch ID,state and version from Cluster name

#export Token as OCM_TOKEN
provider "ocm" { }
data "ocm_cluster_rosa_classic" "mycluster-name" {
    name = "mycluster"
}
output "cluster_id"{
    value = data.ocm_cluster_rosa_classic.mycluster-name.id
}
output "cluster_status"{
    value = data.ocm_cluster_rosa_classic.mycluster-name.state
}

output "cluster_version"{
    value = data.ocm_cluster_rosa_classic.mycluster-name.version
}

- [ ] Test 2: fetech Name, state and version from Cluster ID

#export Token as OCM_TOKEN
provider "ocm" { }


data "ocm_cluster_rosa_classic" "mycluster-id" {
    id = "<cluster id>"
}

output "cluster_name"{
    value = data.ocm_cluster_rosa_classic.mycluster-id.name
}

output "cluster_status"{
    value = data.ocm_cluster_rosa_classic.mycluster-id.state
}

output "cluster_version"{
    value = data.ocm_cluster_rosa_classic.mycluster-id.version
}

- [ ] Test 3: No cluster exists

#export Token as OCM_TOKEN
provider "ocm" { }


data "ocm_cluster_rosa_classic" "mycluster" {
    name = "dummy"  # errors out
}

output "cluster_name"{
    value = data.ocm_cluster_rosa_classic.mycluster-id.name
}


**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [ X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X ] I have commented my code, particularly in hard-to-understand areas
- [X ] I have made corresponding changes to the documentation
- [ X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X ] New and existing unit tests pass locally with my changes
- [X ] Any dependent changes have been merged and published in downstream modules
